### PR TITLE
don't jump around when lots of daily actives

### DIFF
--- a/daily.html
+++ b/daily.html
@@ -52,12 +52,12 @@ function interpolate(a, b, n) {
   <canvas id="grid"></canvas>
 </div>
 
-<div id="day-info" style="float:right; text-align:right; display:none">
+<div id="day-info" style="float:right; text-align:right;">
   <div><ins id="day"> </ins></div>
   <div><ins id="day-users"> </ins> users</div>
 </div>
 
-<div id="user-info" style="display:none">
+<div id="user-info">
   <img id="user-img" style="float:left; height: 80px; margin: 8px" alt="">
   <div>Name: <span id="user-name"> </span></div>
   <div>User: <a id="user-link"><span id="user-id"> </span></a></div>
@@ -231,7 +231,7 @@ function dayStr(day) {
 function setHighlight(userI, oldI, dayX, oldX) {
   var userId = userIds[userI]
   if (userId) {
-    userInfo.style.display = ''
+    userInfo.style.visibility = 'visible'
     userLink.href = userId ?
       'http://localhost:7777/#/profile/' + encodeURIComponent(userId) : ''
     userIdText.nodeValue = userId || ''
@@ -243,15 +243,15 @@ function setHighlight(userI, oldI, dayX, oldX) {
     firstText.nodeValue = dayStr(userFirst[userI])
     lastText.nodeValue = dayStr(userLast[userI])
   } else {
-    userInfo.style.display = 'none'
+    userInfo.style.visibility = 'hidden'
   }
 
   if (dayX >= 0) {
-    dayInfo.style.display = ''
+    dayInfo.style.visibility = 'visible'
     dayText.nodeValue = dayStr(dayX)
     dayUsersText.nodeValue = (grid[dayX] || '').length
   } else {
-    dayInfo.style.display = 'none'
+    dayInfo.style.visibility = 'hidden'
   }
 
   var imgData = ctx.getImageData(0, 0, canvas.width, canvas.height)


### PR DESCRIPTION
due to the recent surge in activity,

![snapshot144](https://cloud.githubusercontent.com/assets/719605/24793731/3c159ee8-1bd7-11e7-90de-ea3b170a67e4.png)

the daily graph now takes up the whole vertical space, which means the user highlight changes the vertical scroll when on or not. this is a quick fix so that the user info always takes up space, so it doesn't jig the scroll.