### PR TITLE
ignore fake-old messages

### DIFF
--- a/active-daily.js
+++ b/active-daily.js
@@ -3,34 +3,48 @@ var pull = require('pull-stream')
 module.exports = function (ssb, cb) {
   var activity = []
   var users = {}
-  var beginDay
+  var beginDay = Math.floor(Date.now() /86400000)
   var numUsers = 0
   var userIds = []
   var userNames = []
   var userImages = []
+  var too_old = +new Date('2015-01-01')
 
   pull(
     ssb.createFeedStream(),
-    pull.drain(function (msg) {
-      if(!msg.value.timestamp) throw new Error('weird')
-      var day = Math.floor(msg.value.timestamp / 86400000)
-      if (!beginDay) beginDay = day
-      day -= beginDay
-      var usersA = activity[day] || (activity[day] = [])
-      var author = msg.value.author
-      if (!(author in users)) {
-        userIds[numUsers] = author
-        users[author] = numUsers++
+    pull.filter(function (data) {
+      return data.value.timestamp > too_old
+    }),
+    pull.collect(function (err, ary) {
+      if(err) return cb(err)
+      for(var i = 0; i < ary.length ; i++) {
+        var day = Math.floor(ary[i].value.timestamp / 86400000)
+        if(day < beginDay) {
+          console.error(ary[i], new Date(ary[i].value.timestamp))
+          beginDay = day //Math.floor(Math.min(,  beginDay))
+        }
       }
-      var userI = users[author]
-      usersA[userI] = true
-      var c = msg.value.content
-      if (c && c.type == 'about' && c.about == author) {
-        if (c.name) userNames[userI] = c.name
-        if (c.image) userImages[userI] = c.image.link
-      }
-    }, function (err) {
-      if (err) return cb(err)
+      console.error('beginDay', beginDay)
+
+      ary.forEach(function (msg) {
+        if(!msg.value.timestamp) throw new Error('weird')
+        var day = Math.floor(msg.value.timestamp / 86400000)
+//        if (!beginDay) beginDay = day
+        day -= beginDay
+        var usersA = activity[day] || (activity[day] = [])
+        var author = msg.value.author
+        if (!(author in users)) {
+          userIds[numUsers] = author
+          users[author] = numUsers++
+        }
+        var userI = users[author]
+        usersA[userI] = true
+        var c = msg.value.content
+        if (c && c.type == 'about' && c.about == author) {
+          if (c.name) userNames[userI] = c.name
+          if (c.image) userImages[userI] = c.image.link
+        }
+      })
       cb(null, {
         beginDay: beginDay,
         activity: activity,
@@ -38,6 +52,15 @@ module.exports = function (ssb, cb) {
         names: userNames,
         images: userImages
       })
+
     })
   )
 }
+
+
+
+
+
+
+
+

--- a/daily.html
+++ b/daily.html
@@ -128,7 +128,8 @@ getJSON('daily.json', function (err, data) {
   var h = userIds.length
   // canvas.style.width = '100%'
 
-  pixelW = Math.floor(window.innerWidth / w)
+  console.log('grid', window.innerWidth, w, window.innerWidth/ w)
+  pixelW = Math.max(Math.floor(window.innerWidth / w), 1)
   pixelH = pixelW
 
   // make the grid like a stacked histogram
@@ -158,6 +159,7 @@ getJSON('daily.json', function (err, data) {
 
 function drawAll() {
   var w = grid.length, h = canvasH
+  console.log(w , h , pixelW, pixelH)
   var imgData = ctx.createImageData(w * pixelW, h * pixelH)
   for (var x = 0; x < w; x++)
     for (var y = 0; y < grid[x].length; y++)


### PR DESCRIPTION
The other day @keks inadvertantly posted a message that had a timestamp in seconds not milliseconds, which appeared to be sometime in 1970. Now it ignores messages older than 2015, and the graph looks right again.